### PR TITLE
Client's do_task should wait

### DIFF
--- a/lib/gearman/client.rb
+++ b/lib/gearman/client.rb
@@ -142,7 +142,7 @@ class Client
 
     taskset = TaskSet.new(self)
     taskset.add_task(task)
-    taskset.wait
+    taskset.wait(nil)
 
     failed ? nil : result
   end


### PR DESCRIPTION
The default wait is 1 second, but a clients 'do' (our do_task) should wait until something is returned.  According to the spec, only backgrounds jobs are detached, yeah?

Possibly switch this around and have `taskset`'s `wait` method have it's `timeout` value defaulted to `nil` ?
