### PR TITLE
Detecting end of command response

### DIFF
--- a/lib/gearman/server.rb
+++ b/lib/gearman/server.rb
@@ -48,7 +48,7 @@ class Server
     while true do 
       if buf = socket.recv_nonblock(65536) rescue nil
         response << buf 
-        return response if response =~ /\n.\n$/
+        return response if response =~ /.\n$/
       end
     end
   end


### PR DESCRIPTION
The original regex fails when the command response is simply "." (without quotes, of course).
E.g. The output of the "status" command when there are no workers and no jobs is simply "."

The correct regex should probably be just /.\n$/.
