### PR TITLE
Fix example

### DIFF
--- a/examples/client.rb
+++ b/examples/client.rb
@@ -8,7 +8,7 @@ servers = ['localhost:4730', 'localhost:4731']
 client = Gearman::Client.new(servers)
 taskset = Gearman::TaskSet.new(client)
 
-task = Gearman::Task.new('sleep', 20)
+task = Gearman::Task.new('sleep', '20')
 task.on_complete {|d| puts d }
 
 taskset.add_task(task)


### PR DESCRIPTION
Hi.  I fixed a small bug in one of the examples.  The job data takes a string here and Ruby throws "TypeError: can't convert Fixnum into String" if an integer is used.
