### PR TITLE
Fix: do_task must wait until the task has been finished

### DIFF
--- a/lib/gearman/client.rb
+++ b/lib/gearman/client.rb
@@ -156,7 +156,7 @@ class Client
 
     taskset = TaskSet.new(self)
     if taskset.add_task(task)
-      taskset.wait
+      taskset.wait(nil)
     else
       raise JobQueueError, "Unable to enqueue job."
     end


### PR DESCRIPTION
This bug has already been fixed here: https://github.com/gearman-ruby/gearman-ruby/pull/6 and landed in the release 3.0.5. But this release is no more available and the bug is there again.
