### PR TITLE
Use connection's hostport when propagating NetworkError

### DIFF
--- a/lib/gearman/client.rb
+++ b/lib/gearman/client.rb
@@ -98,7 +98,7 @@ module Gearman
           raise ProtocolError, message
         end
       rescue NetworkError
-        message = "Network error on read from #{hostport} while adding job, marking server bad"
+        message = "Network error on read from #{connection.hostport} while adding job, marking server bad"
         logger.error message
         raise NetworkError, message
       rescue NoJobServersError

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -51,6 +51,19 @@ describe Gearman::Client do
 
   end
 
+  it 'propagates NetworkErrors while submitting jobs' do
+    mock_connection = double(Gearman::Connection)
+    mock_connection.stub(:send_request).and_raise(Gearman::NetworkError)
+    mock_connection.stub(:hostport).and_return("localhost:4730")
+
+    @mock_connection_pool.stub(:get_connection) { mock_connection }
+
+    task = Gearman::Task.new("queue", "data")
+
+    expect {
+      @client.submit_job(task)
+    }.to raise_error(Gearman::NetworkError)
+  end
 
 
   it "should raise a NetworkError when it didn't write as much as expected to a socket" do


### PR DESCRIPTION
Fixes #23.
